### PR TITLE
Add Borderlands dataset configuration

### DIFF
--- a/DATASET.yaml
+++ b/DATASET.yaml
@@ -4,3 +4,4 @@ robonet_train_dataset: /dev/null/train
 robonet_test_dataset: /dev/null/test
 robodesk_dataset: /dev/null
 robosuite_dataset: /dev/null
+borderlands_dataset: /absolute/path/to/borderlands

--- a/ivideogpt/data/dataset_mixes.py
+++ b/ivideogpt/data/dataset_mixes.py
@@ -183,6 +183,7 @@ DATASET_NAMED_MIXES = {
     "robonet": [("robo_net", 1.0)],
     "tfds_robonet": [("tfds_robonet", 1.0)],
     "bair": [("bair_robot_pushing", 1.0)],
+    "borderlands": [("borderlands", 1.0)],
     "vp2_robodesk": [("vp2_robodesk", 1.0)],
     "vp2_robosuite": [("vp2_robosuite", 1.0)],
     "select": OXE_SELECT,

--- a/ivideogpt/data/simple_dataloader.py
+++ b/ivideogpt/data/simple_dataloader.py
@@ -62,6 +62,7 @@ def get_base_stepsize(dataset_name):
 
         # downstream tasks
         'bair_robot_pushing': 1,
+        'borderlands': 1,
         'vp2_robodesk': 1,
         'vp2_robosuite': 1,
     }
@@ -90,6 +91,7 @@ def get_display_key(dataset_name):
 
         # downstream tasks
         'bair_robot_pushing': 'aux1_image',
+        'borderlands': 'image',
         'vp2_robodesk': 'image',
         'vp2_robosuite': 'image',
     }


### PR DESCRIPTION
## Summary
- Add `borderlands` dataset mix and configuration
- Include default stepsize and display key for Borderlands dataset
- Reference Borderlands dataset path in `DATASET.yaml`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924e5dea14832da2c6cdcb7a9ccd9d